### PR TITLE
Use Snappy compression for the RocksDB benchmark

### DIFF
--- a/wrappers/couch_rocksdb.cc
+++ b/wrappers/couch_rocksdb.cc
@@ -57,7 +57,7 @@ couchstore_error_t couchstore_open_db_ex(const char *filename,
 
     ppdb->options = new rocksdb::Options();
     ppdb->options->create_if_missing = true;
-    ppdb->options->compression = rocksdb::kNoCompression;
+    ppdb->options->compression = rocksdb::kSnappyCompression;
 
     ppdb->options->max_background_compactions = 8;
     ppdb->options->max_background_flushes = 8;


### PR DESCRIPTION
Using Snappy improves the read and write performance on my machine.
Reads are about 15% faster, writes about 50% faster.
