### PR TITLE
Update forestdb headers for correct compilation

### DIFF
--- a/include/libforestdb/fdb_errors.h
+++ b/include/libforestdb/fdb_errors.h
@@ -122,7 +122,7 @@ typedef enum {
      */
     FDB_RESULT_INVALID_COMPACTION_MODE = -22,
     /**
-     * Other thread is opening the file.
+     * Operation cannot be performed as file handle has not been closed.
      */
     FDB_RESULT_FILE_IS_BUSY = -23,
     /**
@@ -154,9 +154,26 @@ typedef enum {
      */
     FDB_RESULT_INVALID_HANDLE = -30,
     /**
-     * General database opertion fails.
+     * A KV store not found in database.
      */
-    FDB_RESULT_FAIL = -100
+    FDB_RESULT_KV_STORE_NOT_FOUND = -31,
+    /**
+     * There is an opened handle of the KV store.
+     */
+    FDB_RESULT_KV_STORE_BUSY = -32,
+    /**
+     * Same KV instance name already exists.
+     */
+    FDB_RESULT_INVALID_KV_INSTANCE_NAME = -33,
+    /**
+     * Custom compare function is assigned incorrectly.
+     */
+    FDB_RESULT_INVALID_CMP_FUNCTION = -34,
+    /**
+     * DB file can't be destroyed as the file is being compacted.
+     * Please retry in sometime.
+     */
+    FDB_RESULT_IN_USE_BY_COMPACTOR = -35,
 } fdb_status;
 
 #ifdef __cplusplus

--- a/include/libforestdb/fdb_types.h
+++ b/include/libforestdb/fdb_types.h
@@ -31,6 +31,21 @@
 #endif
 #endif
 
+/**
+ * Maximum key length supported.
+ * Note that we plan to support a longer key that is greater than
+ * the current max size 3840 bytes
+ */
+#define FDB_MAX_KEYLEN (3840)
+/**
+ * Maximum metadata length supported.
+ */
+#define FDB_MAX_METALEN (65535UL) // 2^16 - 1
+/**
+ * Maximum value length supported.
+ */
+#define FDB_MAX_BODYLEN (4294967295UL) // 2^32 - 1
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -41,12 +56,12 @@ extern "C" {
 typedef uint32_t fdb_open_flags;
 enum {
     /**
-     * Open the database with read-write mode and
+     * Open a ForestDB file with read-write mode and
      * create a new empty ForestDB file if it doesn't exist.
      */
     FDB_OPEN_FLAG_CREATE = 1,
     /**
-     * Open the database in read only mode, but
+     * Open a ForestDB file in read only mode, but
      * return an error if a file doesn't exist.
      */
     FDB_OPEN_FLAG_RDONLY = 2
@@ -151,25 +166,24 @@ typedef struct {
      * Chunk size (bytes) that is used to build B+-tree at each level.
      * It is set to 8 bytes by default and has a min value of 4 bytes
      * and a max value of 64 bytes.
-     * This is a local config to each ForestDB database instance.
+     * This is a local config to each ForestDB file.
      */
     uint16_t chunksize;
     /**
      * Size of block that is a unit of IO operations.
      * It is set to 4KB by default and has a min value of 1KB and a max value of
-     * 128KB. This is a global config that is used across all ForestDB database
-     * instances.
+     * 128KB. This is a global config that is used across all ForestDB files.
      */
     uint32_t blocksize;
     /**
      * Buffer cache size in bytes. If the size is set to zero, then the buffer
      * cache is disabled. This is a global config that is used across all
-     * ForestDB database instances.
+     * ForestDB files.
      */
     uint64_t buffercache_size;
     /**
      * WAL index size threshold in memory (4096 entries by default).
-     * This is a local config to each ForestDB database instance.
+     * This is a local config to each ForestDB file.
      */
     uint64_t wal_threshold;
     /**
@@ -180,45 +194,45 @@ typedef struct {
     /**
      * Interval for purging logically deleted documents in the unit of second.
      * It is set to 0 second (purge during next compaction) by default.
-     * This is a local config to each ForestDB database instance.
+     * This is a local config to each ForestDB file.
      */
     uint32_t purging_interval;
     /**
      * Flag to enable or disable a sequence B+-Tree.
-     * This is a local config to each ForestDB database instance.
+     * This is a local config to each ForestDB file.
      */
     fdb_seqtree_opt_t seqtree_opt;
     /**
      * Flag to enable synchronous or asynchronous commit options.
-     * This is a local config to each ForestDB database instance.
+     * This is a local config to each ForestDB file.
      */
     fdb_durability_opt_t durability_opt;
     /**
      * Flags for fdb_open API. It can be used for specifying read-only mode.
-     * This is a local config to each ForestDB database instance.
+     * This is a local config to each ForestDB file.
      */
     fdb_open_flags flags;
     /**
      * Maximum size (bytes) of temporary buffer for compaction (4MB by default).
-     * This is a local config to each ForestDB database instance.
+     * This is a local config to each ForestDB file.
      */
     uint32_t compaction_buf_maxsize;
     /**
-     * Destroy all the cached blocks in the global buffer cache when a database
+     * Destroy all the cached blocks in the global buffer cache when a ForestDB
      * file is closed. It is set to true by default. This is a global config
-     * that is used across all ForestDB database instances.
+     * that is used across all ForestDB files.
      */
     bool cleanup_cache_onclose;
     /**
      * Compress the body of document when it is written on disk. The compression
      * is disabled by default. This is a global config that is used across all
-     * ForestDB database instances.
+     * ForestDB files.
      */
     bool compress_document_body;
     /**
      * Flag to enable auto compaction for the file. The auto compaction is disabled
      * by default.
-     * This is a local config to each ForestDB database instance.
+     * This is a local config to each ForestDB file.
      */
     fdb_compaction_mode_t compaction_mode;
     /**
@@ -226,42 +240,46 @@ typedef struct {
      * as '(stale data size)/(total file size)'. The compaction daemon triggers
      * compaction if this threshold is satisfied.
      * Compaction will not be performed when this value is set to zero or 100.
-     * This is a local config to each ForestDB database instance.
+     * This is a local config to each ForestDB file.
      */
     uint8_t compaction_threshold;
     /**
      * The minimum filesize to perform compaction.
-     * This is a local config to each ForestDB database instance.
+     * This is a local config to each ForestDB file.
      */
     uint64_t compaction_minimum_filesize;
     /**
-     * Duration that the compaction daemon periodically waks up, in the unit of
-     * second. This is a global config that is used across all ForestDB database
-     * instances.
+     * Duration that the compaction daemon periodically wakes up, in the unit of
+     * second. This is a global config that is used across all ForestDB files.
      */
     uint64_t compactor_sleep_duration;
     /**
-     * Customized compare function for fixed size key.
-     * This is a local config to each ForestDB database instance.
-     */
-    fdb_custom_cmp_fixed cmp_fixed;
-    /**
-     * Customized compare function for variable length key.
-     * This is a local config to each ForestDB database instance.
-     */
-    fdb_custom_cmp_variable cmp_variable;
-    /**
      * Flag to enable supporting multiple KV instances in a DB instance.
-     * This is a global config that is used across all ForestDB database
-     * instances.
+     * This is a global config that is used across all ForestDB files.
      */
     bool multi_kv_instances;
+    /**
+     * Duration that prefetching of DB file will be performed when the file
+     * is opened, in the unit of second. If the duration is set to zero,
+     * prefetching is disabled. This is a local config to each ForestDB file.
+     */
+    uint64_t prefetch_duration;
 } fdb_config;
 
+typedef struct {
+    /**
+     * Flag to create a new empty KV store instance in a DB instance,
+     * if it doesn't exist.
+     */
+    bool create_if_missing;
+    /**
+     * Customized compare function for an KV store instance.
+     */
+    fdb_custom_cmp_variable custom_cmp;
+} fdb_kvs_config;
 
 typedef uint64_t fdb_seqnum_t;
-
-typedef uint64_t fdb_kv_ins_id_t;
+#define FDB_SNAPSHOT_INMEM ((fdb_seqnum_t)(-1))
 
 /**
  * ForestDB doc structure definition
@@ -316,29 +334,54 @@ typedef struct fdb_doc_struct {
 typedef void (*fdb_log_callback)(int err_code, const char *err_msg, void *ctx_data);
 
 /**
- *Opaque reference to the database handle, which is exposed in public APIs.
+ * Opaque reference to a ForestDB file handle, which is exposed in public APIs.
  */
-typedef struct _fdb_handle fdb_handle;
+typedef struct _fdb_file_handle fdb_file_handle;
+
+/**
+ * Opaque reference to a ForestDB KV store handle, which is exposed in public APIs.
+ */
+typedef struct _fdb_kvs_handle fdb_kvs_handle;
 
 /**
  * ForestDB iterator options.Combinational options can be passed to the iterator.
- * For example, FDB_ITR_METAONLY | FDB_ITR_NO_DELETES means
- * "Return non-deleted key and its metadata only through iterator".
+ * For example, FDB_ITR_SKIP_MIN_KEY | FDB_ITR_SKIP_MAX_KEY means
+ * "The smallest and largest keys in the iteration ragne won't be returned by the
+ * iterator".
  */
-typedef uint8_t fdb_iterator_opt_t;
+typedef uint16_t fdb_iterator_opt_t;
 enum {
     /**
      * Return both key and value through iterator.
      */
     FDB_ITR_NONE = 0x00,
     /**
-     * Return key and its metadata only through iterator.
-     */
-    FDB_ITR_METAONLY = 0x01,
-    /**
      * Return only non-deleted items through iterator.
      */
-    FDB_ITR_NO_DELETES = 0x02
+    FDB_ITR_NO_DELETES = 0x02,
+    /**
+     * The lowest key specified will not be returned by the iterator.
+     */
+    FDB_ITR_SKIP_MIN_KEY = 0x04,
+    /**
+     * The highest key specified will not be returned by the iterator.
+     */
+    FDB_ITR_SKIP_MAX_KEY = 0x08
+};
+
+/**
+ * ForestDB iterator seek options.
+ */
+typedef uint8_t fdb_iterator_seek_opt_t;
+enum {
+    /**
+     * If seek_key does not exist return the next sorted key higher than it.
+     */
+    FDB_ITR_SEEK_HIGHER = 0x00,
+    /**
+     * If seek_key does not exist return the previous sorted key lower than it.
+     */
+    FDB_ITR_SEEK_LOWER = 0x01
 };
 
 /**
@@ -368,34 +411,71 @@ typedef struct _fdb_iterator fdb_iterator;
 typedef int64_t cs_off_t;
 
 /**
- * Information about a given database file
+ * Information about a ForestDB file
  */
 typedef struct {
     /**
-     * A database file name.
+     * A file name.
      */
     const char* filename;
     /**
-     * A new database file name that is used after compaction.
+     * A new file name that is used after compaction.
      */
     const char* new_filename;
     /**
-     * Last sequence number assigned
-     */
-    fdb_seqnum_t last_seqnum;
-    /**
-     * Total number of non-deleted documents
+     * Total number of non-deleted documents aggregated across all KV stores.
      */
     uint64_t doc_count;
     /**
-     * Disk space actively used by database
+     * Disk space actively used by the file.
      */
     uint64_t space_used;
     /**
-     * Total disk space used by database, including stale btree nodes and docs.
+     * Total disk space used by the file, including stale btree nodes and docs.
      */
     uint64_t file_size;
-} fdb_info;
+} fdb_file_info;
+
+/**
+ * Information about a ForestDB KV store
+ */
+typedef struct {
+    /**
+     * A KV store name.
+     */
+    const char* name;
+    /**
+     * Last sequence number assigned.
+     */
+    fdb_seqnum_t last_seqnum;
+    /**
+     * Total number of non-deleted documents in a KV store.
+     */
+    uint64_t doc_count;
+    /**
+     * Disk space actively used by the KV store.
+     */
+    uint64_t space_used;
+    /**
+     * File handle that owns the KV store.
+     */
+    fdb_file_handle* file;
+} fdb_kvs_info;
+
+/**
+ * List of ForestDB KV store names
+ */
+typedef struct {
+    /**
+     * Number of KV store names listed in kvs_names.
+     */
+    size_t num_kvs_names;
+    /**
+     * Pointer to array of KV store names.
+     */
+    char **kvs_names;
+} fdb_kvs_name_list;
+
 
 #ifdef __cplusplus
 }

--- a/include/libforestdb/forestdb.h
+++ b/include/libforestdb/forestdb.h
@@ -27,6 +27,8 @@
     #else
         #define LIBFDB_API extern __declspec(dllimport)
     #endif
+#elif defined __GNUC__
+    #define LIBFDB_API __attribute ((visibility("default")))
 #else
     #define LIBFDB_API
 #endif
@@ -58,69 +60,68 @@ LIBFDB_API
 fdb_config fdb_get_default_config(void);
 
 /**
- * Open the database with a given file name.
- * The database should be closed with fdb_close API call.
+ * Get the default ForestDB KV(Key-Vaule) store configs. Note that multiple KV
+ * store instances can be created in a single ForestDB file.
+ * The general recommendation is to invoke this API to get the default configs
+ * and change some configs if necessary and then pass them to fdb_kvs_open APIs.
  *
- * @param ptr_handle Pointer to the place where ForestDB handle is instantiated
- *        as result of this API call.
- * @param filename Name of database file to be opened.
+ * @return fdb_kvs_config instance that contains the default configs.
+ */
+LIBFDB_API
+fdb_kvs_config fdb_get_default_kvs_config(void);
+
+/**
+ * Open a ForestDB file.
+ * The file should be closed with fdb_close API call.
+ *
+ * @param ptr_fhandle Pointer to the place where ForestDB file handle is
+ *        instantiated as result of this API call.
+ * @param filename Name of the ForestDB file to be opened.
  * @param fconfig Pointer to the config instance that contains ForestDB configs.
  *        If NULL is passed, then we use default settings of ForestDB configs.
  * @return FDB_RESULT_SUCCESS on success.
  */
 LIBFDB_API
-fdb_status fdb_open(fdb_handle **ptr_handle,
+fdb_status fdb_open(fdb_file_handle **ptr_fhandle,
                     const char *filename,
                     fdb_config *fconfig);
 
 /**
- * Open the database with a given file name.
- * The documents in the database will be indexed using the customized compare
- * function. The key size MUST be fixed and same as the chunk_size in the
- * configuration. The typical example is to use a primitive type (e.g., int,
- * double) as a primary key and the numeric compare function as a custom
- * function.
- * The database should be closed with fdb_close API call.
+ * Open a ForestDB file.
+ * Note that if any KV store in the file uses a customized compare function,
+ * then the file should be opened with this API by passing the list of all KV
+ * instance names that use customized compare functions, and their corresponding
+ * customized compare functions.
  *
- * @param ptr_handle Pointer to the place where ForestDB handle is instantiated
- *        as result of this API call.
- * @param filename Name of database file to be opened.
+ * Documents in the file will be indexed using their corresponding
+ * customized compare functions. The file should be closed with fdb_close
+ * API call.
+ *
+ * @param ptr_fhandle Pointer to the place where ForestDB file handle is
+ *        instantiated as result of this API call.
+ * @param filename Name of the ForestDB file to be opened.
  * @param fconfig Pointer to the config instance that contains ForestDB configs.
- *        If NULL is passed, then it returns FDB_RESULT_INVALID_ARGS to the caller.
- *        The function pointer "fdb_custom_cmp_fixed" in fdb_config should be
- *        set by an application.
+ *        If NULL is passed, then we use default settings of ForestDB configs.
+ * @param num_functions The number of customized compare functions.
+ * @param kvs_names List of KV store names to be indexed using the customized
+ *        compare functions.
+ * @param functions List of customized compare functions corresponding to each
+ *        KV store listed in kvs_names.
  * @return FDB_RESULT_SUCCESS on success.
  */
 LIBFDB_API
-fdb_status fdb_open_cmp_fixed(fdb_handle **ptr_handle,
-                              const char *filename,
-                              fdb_config *fconfig);
-
-/**
- * Open the database with a given file name.
- * The documents in the database will be indexed using the customized compare
- * function. The key size can be variable.
- * The database should be closed with fdb_close API call.
- *
- * @param ptr_handle Pointer to the place where ForestDB handle is instantiated
- *        as result of this API call.
- * @param filename Name of database file to be opened.
- * @param fconfig Pointer to the config instance that contains ForestDB configs.
- *        If NULL is passed, then it returns FDB_RESULT_INVALID_ARGS to the caller.
- *        The function pointer "fdb_custom_cmp_variable" in fdb_config should be
- *        set by an application.
- * @return FDB_RESULT_SUCCESS on success.
- */
-LIBFDB_API
-fdb_status fdb_open_cmp_variable(fdb_handle **ptr_handle,
-                                 const char *filename,
-                                 fdb_config *fconfig);
+fdb_status fdb_open_custom_cmp(fdb_file_handle **ptr_fhandle,
+                               const char *filename,
+                               fdb_config *fconfig,
+                               size_t num_functions,
+                               char **kvs_names,
+                               fdb_custom_cmp_variable *functions);
 
 /**
  * Set up the error logging callback that allows an application to process
  * error code and message from ForestDB.
  *
- * @param handle Pointer to ForestDB handle.
+ * @param handle Pointer to ForestDB KV store handle.
  * @param log_callback Logging callback function that receives and processes
  *        error codes and messages from ForestDB.
  * @param ctx_data Pointer to application-specific context data that is going
@@ -128,7 +129,7 @@ fdb_status fdb_open_cmp_variable(fdb_handle **ptr_handle,
  * @return FDB_RESULT_SUCCESS on success.
  */
 LIBFDB_API
-fdb_status fdb_set_log_callback(fdb_handle *handle,
+fdb_status fdb_set_log_callback(fdb_kvs_handle *handle,
                                 fdb_log_callback log_callback,
                                 void *ctx_data);
 
@@ -156,7 +157,7 @@ fdb_status fdb_doc_create(fdb_doc **doc,
 
 /**
  * Update a FDB_DOC instance with a given metadata and body.
- * Note that this API does not update the ForestDB database, but
+ * Note that this API does not update an item in the ForestDB KV store, but
  * instead simply update a given FDB_DOC instance only.
  *
  * @param doc Pointer to a FDB_DOC instance to be updated.
@@ -187,13 +188,13 @@ fdb_status fdb_doc_free(fdb_doc *doc);
  * Note that FDB_DOC instance should be created by calling
  * fdb_doc_create(doc, key, keylen, NULL, 0, NULL, 0) before using this API.
  *
- * @param handle Pointer to ForestDB handle.
+ * @param handle Pointer to ForestDB KV store handle.
  * @param doc Pointer to ForestDB doc instance whose metadata and doc body
  *        are populated as a result of this API call.
  * @return FDB_RESULT_SUCCESS on success.
  */
 LIBFDB_API
-fdb_status fdb_get(fdb_handle *handle,
+fdb_status fdb_get(fdb_kvs_handle *handle,
                    fdb_doc *doc);
 
 /**
@@ -201,7 +202,7 @@ fdb_status fdb_get(fdb_handle *handle,
  * Note that FDB_DOC instance should be created by calling
  * fdb_doc_create(doc, key, keylen, NULL, 0, NULL, 0) before using this API.
  *
- * @param handle Pointer to ForestDB handle.
+ * @param handle Pointer to ForestDB KV store handle.
  * @param doc Pointer to ForestDB doc instance whose metadata including the offset
  *        on disk is populated as a result of this API call.
  *        Note that the offset returned can be used by fdb_get_byoffset API to
@@ -209,7 +210,7 @@ fdb_status fdb_get(fdb_handle *handle,
  * @return FDB_RESULT_SUCCESS on success.
  */
 LIBFDB_API
-fdb_status fdb_get_metaonly(fdb_handle *handle,
+fdb_status fdb_get_metaonly(fdb_kvs_handle *handle,
                             fdb_doc *doc);
 
 /**
@@ -217,13 +218,13 @@ fdb_status fdb_get_metaonly(fdb_handle *handle,
  * Note that FDB_DOC instance should be created by calling
  * fdb_doc_create(doc, NULL, 0, NULL, 0, NULL, 0) before using this API.
  *
- * @param handle Pointer to ForestDB handle.
+ * @param handle Pointer to ForestDB KV store handle.
  * @param doc Pointer to ForestDB doc instance whose key, metadata and doc body
  *        are populated as a result of this API call.
  * @return FDB_RESULT_SUCCESS on success.
  */
 LIBFDB_API
-fdb_status fdb_get_byseq(fdb_handle *handle,
+fdb_status fdb_get_byseq(fdb_kvs_handle *handle,
                          fdb_doc *doc);
 
 /**
@@ -231,7 +232,7 @@ fdb_status fdb_get_byseq(fdb_handle *handle,
  * Note that FDB_DOC instance should be created by calling
  * fdb_doc_create(doc, NULL, 0, NULL, 0, NULL, 0) before using this API.
  *
- * @param handle Pointer to ForestDB handle.
+ * @param handle Pointer to ForestDB KV store handle.
  * @param doc Pointer to ForestDB doc instance whose key and metadata including
  *        the offset on disk are populated as a result of this API call.
  *        Note that the offset returned can be used by fdb_get_byoffset API to
@@ -239,23 +240,23 @@ fdb_status fdb_get_byseq(fdb_handle *handle,
  * @return FDB_RESULT_SUCCESS on success.
  */
 LIBFDB_API
-fdb_status fdb_get_metaonly_byseq(fdb_handle *handle,
+fdb_status fdb_get_metaonly_byseq(fdb_kvs_handle *handle,
                                   fdb_doc *doc);
 
 /**
- * Retrieve a doc's metadata and body with a given doc offset in the database file.
+ * Retrieve a doc's metadata and body with a given doc offset in the file.
  * Note that FDB_DOC instance should be first instantiated and populated
  * by calling fdb_get_metaonly, fdb_get_metaonly_byseq, or
  * fdb_iterator_next_offset, which returns an offset to a doc. Then,
  * the FDB_DOC instance and the offset should be passed together to this API.
  *
- * @param handle Pointer to ForestDB handle.
+ * @param handle Pointer to ForestDB KV store handle.
  * @param doc Pointer to ForestDB doc instance that contains the offset to a doc
  *        and whose doc body is populated as a result of this API call.
  * @return FDB_RESULT_SUCCESS on success.
  */
 LIBFDB_API
-fdb_status fdb_get_byoffset(fdb_handle *handle,
+fdb_status fdb_get_byoffset(fdb_kvs_handle *handle,
                             fdb_doc *doc);
 
 /**
@@ -265,12 +266,12 @@ fdb_status fdb_get_byoffset(fdb_handle *handle,
  * this API. Setting "deleted" flag in FDB_DOC instance to true is equivalent to
  * calling fdb_del api described below.
  *
- * @param handle Pointer to ForestDB handle.
+ * @param handle Pointer to ForestDB KV store handle.
  * @param doc Pointer to ForestDB doc instance that is used to update a key.
  * @return FDB_RESULT_SUCCESS on success.
  */
 LIBFDB_API
-fdb_status fdb_set(fdb_handle *handle,
+fdb_status fdb_set(fdb_kvs_handle *handle,
                    fdb_doc *doc);
 
 /**
@@ -279,19 +280,19 @@ fdb_status fdb_set(fdb_handle *handle,
  * fdb_doc_create(doc, key, keylen, meta, metalen, body, bodylen) before using
  * this API.
  *
- * @param handle Pointer to ForestDB handle.
+ * @param handle Pointer to ForestDB KV store handle.
  * @param doc Pointer to ForestDB doc instance that is used to delete a key.
  * @return FDB_RESULT_SUCCESS on success.
  */
 LIBFDB_API
-fdb_status fdb_del(fdb_handle *handle,
+fdb_status fdb_del(fdb_kvs_handle *handle,
                    fdb_doc *doc);
 
 /**
  * Simplified API for fdb_get:
  * Retrieve the value (doc body in fdb_get) for a given key.
  *
- * @param handle Pointer to ForestDB handle.
+ * @param handle Pointer to ForestDB KV store handle.
  * @param key Pointer to the key to be retrieved.
  * @param keylen Length of the key.
  * @param value_out Pointer to the value as a result of this API call. Note that this
@@ -300,7 +301,7 @@ fdb_status fdb_del(fdb_handle *handle,
  * @return FDB_RESULT_SUCCESS on success.
  */
 LIBFDB_API
-fdb_status fdb_get_kv(fdb_handle *handle,
+fdb_status fdb_get_kv(fdb_kvs_handle *handle,
                       void *key, size_t keylen,
                       void **value_out, size_t *valuelen_out);
 
@@ -308,7 +309,7 @@ fdb_status fdb_get_kv(fdb_handle *handle,
  * Simplified API for fdb_set:
  * Update the value (doc body in fdb_set) for a given key.
  *
- * @param handle Pointer to ForestDB handle.
+ * @param handle Pointer to ForestDB KV store handle.
  * @param key Pointer to the key to be updated.
  * @param keylen Length of the key.
  * @param value Pointer to the value corresponding to the key.
@@ -316,7 +317,7 @@ fdb_status fdb_get_kv(fdb_handle *handle,
  * @return FDB_RESULT_SUCCESS on success.
  */
 LIBFDB_API
-fdb_status fdb_set_kv(fdb_handle *handle,
+fdb_status fdb_set_kv(fdb_kvs_handle *handle,
                       void *key, size_t keylen,
                       void *value, size_t valuelen);
 
@@ -324,46 +325,53 @@ fdb_status fdb_set_kv(fdb_handle *handle,
  * Simplified API for fdb_del:
  * Delete a key, and its value (doc body in fdb_del).
  *
- * @param handle Pointer to ForestDB handle.
+ * @param handle Pointer to ForestDB KV store handle.
  * @param key Pointer to the key to be deleted.
  * @param keylen Length of the key.
  * @return FDB_RESULT_SUCCESS on success.
  */
 LIBFDB_API
-fdb_status fdb_del_kv(fdb_handle *handle,
+fdb_status fdb_del_kv(fdb_kvs_handle *handle,
                       void *key, size_t keylen);
 
 /**
- * Commit all pending changes into disk.
+ * Commit all pending changes on a ForestDB file into disk.
+ * Note that this API should be invoked with a ForestDB file handle.
  *
- * @param handle Pointer to ForestDB handle.
+ * @param fhandle Pointer to ForestDB file handle.
  * @param opt Commit option.
  * @return FDB_RESULT_SUCCESS on success.
  */
 LIBFDB_API
-fdb_status fdb_commit(fdb_handle *handle, fdb_commit_opt_t opt);
+fdb_status fdb_commit(fdb_file_handle *fhandle, fdb_commit_opt_t opt);
 
 /**
- * Create an snapshot of a database file in ForestDB.
+ * Create a snapshot of a KV store.
  *
- * @param handle_in ForestDB handle pointer from which snapshot is to be made
- * @param handle_out Pointer to snapshot handle, close with fdb_close()
+ * @param handle_in ForestDB KV store handle pointer from which snapshot is to be made
+ * @param handle_out Pointer to KV store snapshot handle, close with fdb_kvs_close()
  * @param snapshot_seqnum The sequence number or snapshot marker of snapshot.
  *        Note that this seq number should correspond to one of the commits
- *        that have been persisted in the same database instance.
+ *        that have been persisted for a given KV store instance.
+ *        To create an in-memory snapshot for a given KV store, pass
+ *        FDB_SNAPSHOT_INMEM as the sequence number.
+ *        In-memory snapshot is a non-durable consistent copy of the KV store
+ *        instance and carries the latest version of all the keys at the point
+ *        of the snapshot and can even be taken out of uncommitted transaction.
  * @return FDB_RESULT_SUCCESS on success.
  *         FDB_RESULT_INVALID_ARGS if any input param is NULL, or,
  *                                 if sequence number tree is not enabled
  *         Any other error from fdb_open may be returned
  */
 LIBFDB_API
-fdb_status fdb_snapshot_open(fdb_handle *handle_in, fdb_handle **handle_out,
+fdb_status fdb_snapshot_open(fdb_kvs_handle *handle_in, fdb_kvs_handle **handle_out,
                              fdb_seqnum_t snapshot_seqnum);
 
 /**
- * Rollback a database to a specified point represented by the sequence number
+ * Rollback a KV store to a specified point represented by a given sequence
+ * number.
  *
- * @param handle_ptr ForestDB database handle that needs to be rolled back
+ * @param handle_ptr ForestDB KV store handle that needs to be rolled back.
  * @param rollback_seqnum sequence number or rollback point marker of snapshot
  * @return FDB_RESULT_SUCCESS on success.
  *         FDB_RESULT_INVALID_ARGS if any input param is NULL, or,
@@ -371,76 +379,84 @@ fdb_status fdb_snapshot_open(fdb_handle *handle_in, fdb_handle **handle_out,
  *         Any other error from fdb_open may be returned
  */
 LIBFDB_API
-fdb_status fdb_rollback(fdb_handle **handle_ptr, fdb_seqnum_t rollback_seqnum);
+fdb_status fdb_rollback(fdb_kvs_handle **handle_ptr, fdb_seqnum_t rollback_seqnum);
 
 /**
- * Create an iterator to traverse a ForestDB snapshot by key range
+ * Create an iterator to traverse a ForestDB KV store snapshot by key range
  *
- * @param handle Pointer to ForestDB handle.
+ * @param handle Pointer to ForestDB KV store handle.
  * @param iterator Pointer to the place where the iterator is created
  *        as a result of this API call.
- * @param start_key Pointer to the start key. Passing NULL means that
- *        it wants to start with the smallest key in the database.
- * @param start_keylen Length of the start key.
- * @param end_key Pointer to the end key. Passing NULL means that it wants
- *        to end with the largest key in the database.
- * @param end_keylen Length of the end key.
+ * @param min_key Pointer to the smallest key. Passing NULL means that
+ *        it wants to start with the smallest key in the KV store.
+ * @param min_keylen Length of the smallest key.
+ * @param max_key Pointer to the largest key. Passing NULL means that it wants
+ *        to end iteration with the largest key in the KV store.
+ * @param max_keylen Length of the largest key.
  * @param opt Iterator option.
  * @return FDB_RESULT_SUCCESS on success.
  */
 LIBFDB_API
-fdb_status fdb_iterator_init(fdb_handle *handle,
+fdb_status fdb_iterator_init(fdb_kvs_handle *handle,
                              fdb_iterator **iterator,
-                             const void *start_key,
-                             size_t start_keylen,
-                             const void *end_key,
-                             size_t end_keylen,
+                             const void *min_key,
+                             size_t min_keylen,
+                             const void *max_key,
+                             size_t max_keylen,
                              fdb_iterator_opt_t opt);
 
 /**
- * Create an iterator to traverse a ForestDB snapshot by sequence number range
+ * Create an iterator to traverse a ForestDB KV store snapshot by sequence
+ * number range
  *
- * @param handle Pointer to ForestDB handle.
+ * @param handle Pointer to ForestDB KV store handle.
  * @param iterator Pointer to the iterator to be created as a result of
  *        this API call.
- * @param start_seq Starting document sequence number to begin iteration from
- * @param end_seq Ending sequence number indicating the last iterated item.
- *        Passing 0 means that it wants to end with the latest key
+ * @param min_seq Smallest document sequence number of the iteration.
+ * @param max_seq Largest document sequence number of the iteration.
+ *        Passing 0 means that it wants iteration to end with the latest
+ *        mutation
  *
  * @param opt Iterator option.
  * @return FDB_RESULT_SUCCESS on success.
  */
 LIBFDB_API
-fdb_status fdb_iterator_sequence_init(fdb_handle *handle,
+fdb_status fdb_iterator_sequence_init(fdb_kvs_handle *handle,
                              fdb_iterator **iterator,
-                             const fdb_seqnum_t start_seq,
-                             const fdb_seqnum_t end_seq,
+                             const fdb_seqnum_t min_seq,
+                             const fdb_seqnum_t max_seq,
                              fdb_iterator_opt_t opt);
 
 /**
- * Get the prev item (key, metadata, doc body) from the iterator.
+ * Moves the iterator backward by one.
+ *
+ * @param iterator Pointer to the iterator.
+ * @return FDB_RESULT_SUCCESS on success.
+ */
+LIBFDB_API
+fdb_status fdb_iterator_prev(fdb_iterator *iterator);
+
+/**
+ * Moves the iterator forward by one.
+ *
+ * @param iterator Pointer to the iterator.
+ * @return FDB_RESULT_SUCCESS on success.
+ */
+LIBFDB_API
+fdb_status fdb_iterator_next(fdb_iterator *iterator);
+
+/**
+ * Get the item (key, metadata, doc body) from the iterator.
  *
  * @param iterator Pointer to the iterator.
  * @param doc Pointer to FDB_DOC instance to be populated by the iterator.
  * @return FDB_RESULT_SUCCESS on success.
  */
 LIBFDB_API
-fdb_status fdb_iterator_prev(fdb_iterator *iterator,
-                             fdb_doc **doc);
+fdb_status fdb_iterator_get(fdb_iterator *iterator, fdb_doc **doc);
 
 /**
- * Get the next item (key, metadata, doc body) from the iterator.
- *
- * @param iterator Pointer to the iterator.
- * @param doc Pointer to FDB_DOC instance to be populated by the iterator.
- * @return FDB_RESULT_SUCCESS on success.
- */
-LIBFDB_API
-fdb_status fdb_iterator_next(fdb_iterator *iterator,
-                             fdb_doc **doc);
-
-/**
- * Get the next item (key, metadata, offset to doc body) from the iterator.
+ * Get item metadata only(key, metadata, offset to doc body) from the iterator.
  *
  * @param iterator Pointer to the iterator.
  * @param doc Pointer to FDB_DOC instance to be populated by the iterator.
@@ -449,21 +465,42 @@ fdb_status fdb_iterator_next(fdb_iterator *iterator,
  * @return FDB_RESULT_SUCCESS on success.
  */
 LIBFDB_API
-fdb_status fdb_iterator_next_metaonly(fdb_iterator *iterator,
-                                      fdb_doc **doc);
+fdb_status fdb_iterator_get_metaonly(fdb_iterator *iterator, fdb_doc **doc);
 
 /**
- * Fast forward an iterator to return documents after the given seek_key
- * If the key does not exist, seek forward to the next sorted key.
+ * Fast forward / backward an iterator to return documents starting from
+ * the given seek_key. If the seek key does not exist, the iterator is
+ * positioned to start from the next sorted key.
  *
  * @param iterator Pointer to the iterator.
  * @param seek_key Pointer to the key to seek to.
  * @param seek_keylen Length of the seek_key
+ * @param direction Specifies which key to return if seek_key does not exist
+ *                  default value of 0 indicates FDB_ITR_SEEK_HIGHER
  * @return FDB_RESULT_SUCCESS on success.
  */
 LIBFDB_API
 fdb_status fdb_iterator_seek(fdb_iterator *iterator, const void *seek_key,
-                             const size_t seek_keylen);
+                             const size_t seek_keylen,
+                             const fdb_iterator_seek_opt_t direction);
+
+/**
+ * Rewind an iterator to position at the smallest key of the iteration.
+ *
+ * @param iterator Pointer to the iterator.
+ * @return FDB_RESULT_SUCCESS on success.
+ */
+LIBFDB_API
+fdb_status fdb_iterator_seek_to_min(fdb_iterator *iterator);
+
+/**
+ * Fast forward an iterator to position at the largest key of the iteration.
+ *
+ * @param iterator Pointer to the iterator.
+ * @return FDB_RESULT_SUCCESS on success.
+ */
+LIBFDB_API
+fdb_status fdb_iterator_seek_to_max(fdb_iterator *iterator);
 
 /**
  * Close the iterator and free its associated resources.
@@ -475,7 +512,7 @@ LIBFDB_API
 fdb_status fdb_iterator_close(fdb_iterator *iterator);
 
 /**
- * Compact the current database file and create a new compacted file.
+ * Compact the current file and create a new compacted file.
  * Note that a new file name passed to this API will be ignored if the compaction
  * mode of the handle is auto-compaction (i.e., FDB_COMPACTION_AUTO). In the auto
  * compaction mode, the name of a new compacted file will be automatically generated
@@ -501,75 +538,138 @@ fdb_status fdb_iterator_close(fdb_iterator *iterator);
  *   ...
  *   fdb_close(db1);
  *   fdb_close(db2); // "test.fdb.2" is automatically renamed to the original
- *                   // file name "test.fdb" because there are no database handles
+ *                   // file name "test.fdb" because there are no file handles
  *                   // on "test.fdb.2".
  *
- * Also note that if a given database file is currently being compacted by the
+ * Also note that if a given ForestDB file is currently being compacted by the
  * compaction daemon, then FDB_RESULT_FILE_IS_BUSY is returned to the caller.
  *
- * @param handle Pointer to ForestDB handle.
- * @param new_filename Name of a new compacted database file.
+ * @param fhandle Pointer to ForestDB file handle.
+ * @param new_filename Name of a new compacted file.
  * @return FDB_RESULT_SUCCESS on success.
  */
 LIBFDB_API
-fdb_status fdb_compact(fdb_handle *handle,
+fdb_status fdb_compact(fdb_file_handle *fhandle,
                        const char *new_filename);
 
 /**
- * Return the overall disk space actively used by the current database file.
+ * Return the overall disk space actively used by a ForestDB file.
  * Note that this doesn't include the disk space used by stale btree nodes
  * and docs.
  *
- * @param handle Pointer to ForestDB handle.
+ * @param fhandle Pointer to ForestDB file handle.
  * @return FDB_RESULT_SUCCESS on success.
  */
 LIBFDB_API
-size_t fdb_estimate_space_used(fdb_handle *handle);
+size_t fdb_estimate_space_used(fdb_file_handle *fhandle);
 
 /**
- * Return the information about a given database handle.
+ * Return the information about a ForestDB file.
  *
- * @param handle Pointer to ForestDB handle.
- * @param info Pointer to ForestDB Info instance.
+ * @param fhandle Pointer to ForestDB file handle.
+ * @param info Pointer to ForestDB File Info instance.
  * @return FDB_RESULT_SUCCESS on success.
  */
 LIBFDB_API
-fdb_status fdb_get_dbinfo(fdb_handle *handle, fdb_info *info);
+fdb_status fdb_get_file_info(fdb_file_handle *fhandle, fdb_file_info *info);
 
 /**
- * Change the compaction mode of a given database file referred by the handle passed.
+ * Return the information about a ForestDB KV store instance.
+ *
+ * @param handle Pointer to ForestDB KV store handle.
+ * @param info Pointer to KV Store Info instance.
+ * @return FDB_RESULT_SUCCESS on success.
+ */
+LIBFDB_API
+fdb_status fdb_get_kvs_info(fdb_kvs_handle *handle, fdb_kvs_info *info);
+
+/**
+ * Get the current sequence number of a ForestDB KV store instance.
+ *
+ * @param handle Pointer to ForestDB KV store handle.
+ * @param seqnum Pointer to the variable that sequence number will be returned.
+ * @return FDB_RESULT_SUCCESS on success.
+ */
+LIBFDB_API
+fdb_status fdb_get_kvs_seqnum(fdb_kvs_handle *handle, fdb_seqnum_t *seqnum);
+
+/**
+ * Get all KV store names in a ForestDB file.
+ *
+ * @param fhandle Pointer to ForestDB file handle.
+ * @param kvs_name_list Pointer to a KV store name list. Note that this list
+ *        should be released using fdb_free_kvs_name_list API call().
+ * @return FDB_RESULT_SUCCESS on success.
+ */
+LIBFDB_API
+fdb_status fdb_get_kvs_name_list(fdb_file_handle *fhandle,
+                                 fdb_kvs_name_list *kvs_name_list);
+
+/**
+ * Free a KV store name list.
+ *
+ * @param kvs_name_list Pointer to a KV store name list to be freed.
+ * @return FDB_RESULT_SUCCESS on success.
+ */
+LIBFDB_API
+fdb_status fdb_free_kvs_name_list(fdb_kvs_name_list *kvs_name_list);
+
+/**
+ * Change the compaction mode of a ForestDB file referred by the handle passed.
  * If the mode is changed to auto-compaction (i.e., FDB_COMPACTION_AUTO), the compaction
  * threshold is set to the threshold passed to this API.
- * This API can be also used to change the compaction threshould for a given database
- * file whose compaction mode is currently auto-compaction.
+ * This API can be also used to change the compaction threshould for a ForestDB file
+ * whose compaction mode is currently auto-compaction.
  *
- * Note that all the other handles referring the same database file should be closed
+ * Note that all the other handles referring the same ForestDB file should be closed
  * before this API call, and no concurrent operation should be performed on the same
  * file until the mode switching is done.
  *
- * @param handle Pointer to ForestDB handle.
+ * @param fhandle Pointer to ForestDB file handle.
  * @param mode New compaction mode to be set.
  * @param new_threshold New compaction threshold to be set.
  * @return FDB_RESULT_SUCCESS on success.
  */
 LIBFDB_API
-fdb_status fdb_switch_compaction_mode(fdb_handle *handle,
+fdb_status fdb_switch_compaction_mode(fdb_file_handle *fhandle,
                                       fdb_compaction_mode_t mode,
                                       size_t new_threshold);
 
 /**
- * Close the database file.
+ * Close a ForestDB file.
  *
- * @param handle Pointer to ForestDB handle.
+ * @param fhandle Pointer to ForestDB file handle.
  * @return FDB_RESULT_SUCCESS on success.
  */
 LIBFDB_API
-fdb_status fdb_close(fdb_handle *handle);
+fdb_status fdb_close(fdb_file_handle *fhandle);
+
+/**
+ * Destroy all resources associated with a ForestDB file permanently
+ * (e.g., buffer cache, in-memory WAL, indexes, daemon compaction thread)
+ * including current and past versions of the file.
+ * Note that all handles on the file should be closed through fdb_close
+ * calls before calling this API.
+ * @param filename - the file path that needs to be destroyed
+ * @param fconfig  - the forestdb configuration to determine
+ *                   error log callbacks, manual/auto compaction etc
+ * NOTE: If manual compaction is being used, fdb_destroy() is best-effort only
+ *       and must be called with the correct filename
+ * Reason for best-effort in manual compaction case:
+ * FileA --> FileB --> FileC --> FileA --> FileD --> FileC -->DESTROY
+ * (In above case, FileB cannot be destroyed as its info is not
+ *  reachable from file path "FileC", api will wipe out FileA, FileC and FileD)
+ *
+ * @return FDB_RESULT_SUCCESS on success.
+ */
+LIBFDB_API
+fdb_status fdb_destroy(const char *filename,
+                       fdb_config *fconfig);
 
 /**
  * Destroy all the resources (e.g., buffer cache, in-memory WAL indexes,
  * daemon compaction thread, etc.) and then shutdown the ForestDB engine.
- * Note that all the database files should be closed through fdb_close calls
+ * Note that all the ForestDB files should be closed through fdb_close calls
  * before calling this API.
  *
  * @return FDB_RESULT_SUCCESS on success.
@@ -578,7 +678,7 @@ LIBFDB_API
 fdb_status fdb_shutdown();
 
 /**
- * Begin a transaction with the given database handle and isolation level.
+ * Begin a transaction with a given ForestDB file handle and isolation level.
  * The transaction should be closed with fdb_end_transaction API call.
  * The isolation levels supported are "read committed" or "read uncommitted".
  * We plan to support both serializable and repeatable read isolation levels
@@ -586,47 +686,106 @@ fdb_status fdb_shutdown();
  * please refer to the following link:
  * http://en.wikipedia.org/wiki/Isolation_level
  *
- * @param handle Pointer to ForestDB handle.
+ * @param fhandle Pointer to ForestDB file handle.
  * @param isolation_level Isolation level (i.e., read_committed or read_uncommitted)
  *        of the transaction.
  * @return FDB_RESULT_SUCCESS on success.
  */
 LIBFDB_API
-fdb_status fdb_begin_transaction(fdb_handle *handle,
+fdb_status fdb_begin_transaction(fdb_file_handle *fhandle,
                                  fdb_isolation_level_t isolation_level);
 
 /**
- * End a transaction for the given database handle by commiting all the dirty
+ * End a transaction for a given ForestDB file handle by commiting all the dirty
  * updates and releasing all the resouces allocated for that transaction.
  *
- * @param handle Pointer to ForestDB handle.
+ * @param fhandle Pointer to ForestDB file handle.
  * @param opt Commit option.
  * @return FDB_RESULT_SUCCESS on success.
  */
 LIBFDB_API
-fdb_status fdb_end_transaction(fdb_handle *handle, fdb_commit_opt_t opt);
+fdb_status fdb_end_transaction(fdb_file_handle *fhandle,
+                               fdb_commit_opt_t opt);
 
 /**
- * Abort the transaction for a given handle.
+ * Abort the transaction for a given ForestDB file handle.
  * All uncommitted dirty updates in the handle will be discarded.
  *
- * @param handle Pointer to ForestDB handle.
+ * @param fhandle Pointer to ForestDB file handle.
  * @return FDB_RESULT_SUCCESS on success.
  */
 LIBFDB_API
-fdb_status fdb_abort_transaction(fdb_handle *handle);
+fdb_status fdb_abort_transaction(fdb_file_handle *fhandle);
+
+/**
+ * Open the KV store with a given instance name.
+ * The KV store should be closed with fdb_kvs_close API call.
+ *
+ * @param fhandle Pointer to ForestDB file handle.
+ * @param ptr_handle Pointer to the place where the KV store handle is
+ *        instantiated as a result of this API call.
+ * @param kvs_name The name of KV store to be opened. If the name is not given
+ *        (i.e., NULL is passed), the KV store instance named "default" will be
+ *        returned.
+ * @param config Pointer to the config instance that contains KV store configs.
+ *        If NULL is passed, then we use default settings of KV store configs.
+ * @return FDB_RESULT_SUCCESS on success.
+ */
+LIBFDB_API
+fdb_status fdb_kvs_open(fdb_file_handle *fhandle,
+                        fdb_kvs_handle **ptr_handle,
+                        const char *kvs_name,
+                        fdb_kvs_config *config);
 
 
+/**
+ * Open the default KV store.
+ * The KV store should be closed with fdb_kvs_close API call.
+ *
+ * @param fhandle Pointer to ForestDB file handle.
+ * @param ptr_handle Pointer to the place where the KV store handle is
+ *        instantiated as a result of this API call.
+ * @param config Pointer to the config instance that contains KV store configs.
+ *        If NULL is passed, then we use default settings of KV store configs.
+ * @return FDB_RESULT_SUCCESS on success.
+ */
 LIBFDB_API
-fdb_status fdb_kv_ins_create(fdb_handle *super,
-                             const char *kv_ins_name);
+fdb_status fdb_kvs_open_default(fdb_file_handle *fhandle,
+                                fdb_kvs_handle **ptr_handle,
+                                fdb_kvs_config *config);
 
+/**
+ * Close the KV store handle.
+ *
+ * @param handle Pointer to KV store handle.
+ * @return FDB_RESULT_SUCCESS on success.
+ */
 LIBFDB_API
-fdb_status fdb_kv_ins_open(fdb_handle *super_handle,
-                           const char *kv_ins_name,
-                           fdb_handle **ptr_kv_ins);
+fdb_status fdb_kvs_close(fdb_kvs_handle *handle);
+
+/**
+ * Permanently drop a given KV store instance from a ForestDB file.
+ *
+ * @param fhandle Pointer to ForestDB file handle.
+ * @param kvs_name The name of KV store instance to be removed. If the name is not given
+ *        (i.e., NULL is passed), the KV store instance named "default" will be
+ *        dropped.
+ * @return FDB_RESULT_SUCCESS on success.
+ */
 LIBFDB_API
-fdb_status fdb_kv_ins_close(fdb_handle *kv_ins);
+fdb_status fdb_kvs_remove(fdb_file_handle *fhandle,
+                          const char *kvs_name);
+
+/**
+ * Retrieve ForestDB error code as a string
+ *
+ * @param  err_code Error code
+ * @return A text string that describes an error code. Note that the string
+ *         returned is a constant. The application must not try to modify
+ *         it or try to free the pointer to this string.
+ */
+LIBFDB_API
+const char* fdb_error_msg(fdb_status err_code);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Fix compilation errors with updated forestdb header files.
