### PR TITLE
Use per batch buffer in 'couchstore_save_documents'

### DIFF
--- a/bench/couch_bench.cc
+++ b/bench/couch_bench.cc
@@ -30,7 +30,6 @@
 #define MAX(a,b) (((a)>(b))?(a):(b))
 #define MIN(a,b) (((a)<(b))?(a):(b))
 #define randomize() srand((unsigned)time(NULL))
-
 #ifdef __DEBUG
 #ifndef __DEBUG_COUCHBENCH
     #undef DBG
@@ -41,6 +40,7 @@
     #define DBGSW(n, command...)
 #endif
 #endif
+int64_t DATABUF_MAXLEN = 0; 
 
 struct bench_info {
     uint8_t initialize;  // flag for initialization
@@ -248,6 +248,7 @@ void _create_doc(struct bench_info *binfo,
     BDR_RNG_NEXTPAIR;
     r = get_random(&binfo->bodylen, rngz, rngz2);
     if (r < 8) r = 8;
+    else if(r > DATABUF_MAXLEN) r = DATABUF_MAXLEN; 
 
     doc->data.size = r;
     // align to 8 bytes (sizeof(uint64_t))
@@ -2593,12 +2594,14 @@ struct bench_info get_benchinfo(char* bench_config_filename)
             iniparser_getint(cfg, (char*)"body_length:median", 512);
         binfo.bodylen.b =
             iniparser_getint(cfg, (char*)"body_length:standard_deviation", 32);
+        DATABUF_MAXLEN = binfo.bodylen.a + 5*binfo.bodylen.b;
     }else{
         binfo.bodylen.type = RND_UNIFORM;
         binfo.bodylen.a =
             iniparser_getint(cfg, (char*)"body_length:lower_bound", 448);
         binfo.bodylen.b =
             iniparser_getint(cfg, (char*)"body_length:upper_bound", 576);
+        DATABUF_MAXLEN = binfo.bodylen.b;
     }
     binfo.compressibility =
         iniparser_getint(cfg, (char*)"body_length:compressibility", 100);

--- a/bench/couch_common.h
+++ b/bench/couch_common.h
@@ -30,6 +30,9 @@ extern "C" {
      */
     typedef int64_t cs_off_t;
 
+    /**global variable whose value is set based on user input in bench_config */
+    extern int64_t DATABUF_MAXLEN; 
+
     /** Document content metadata flags */
     typedef uint8_t couchstore_content_meta_flags;
     enum {

--- a/wrappers/couch_leveldb.cc
+++ b/wrappers/couch_leveldb.cc
@@ -157,17 +157,15 @@ couchstore_error_t couchstore_save_documents(Db *db, Doc* const docs[], DocInfo 
 {
     unsigned i;
     uint16_t metalen;
-    uint8_t metabuf[METABUF_MAXLEN];
     uint8_t *buf;
     char *err = NULL;
     leveldb_writebatch_t *wb;
 
     wb = leveldb_writebatch_create();
+    buf = (uint8_t*)malloc(sizeof(metalen) + METABUF_MAXLEN + DATABUF_MAXLEN);
 
     for (i=0;i<numdocs;++i){
-        metalen = _docinfo_to_buf(infos[i], metabuf);
-        buf = (uint8_t*)malloc(sizeof(metalen) + metalen + docs[i]->data.size);
-        memcpy(buf + sizeof(metalen), metabuf, metalen);
+        metalen = _docinfo_to_buf(infos[i], buf + sizeof(metalen));
         memcpy(buf, &metalen, sizeof(metalen));
         memcpy(buf + sizeof(metalen) + metalen, docs[i]->data.buf, docs[i]->data.size);
 
@@ -175,8 +173,8 @@ couchstore_error_t couchstore_save_documents(Db *db, Doc* const docs[], DocInfo 
                                sizeof(metalen) + metalen + docs[i]->data.size);
 
         infos[i]->db_seq = 0;
-        free(buf);
     }
+    free(buf);
     leveldb_write(db->db, db->write_options, wb, &err);
     if (err) {
         printf("ERR %s\n", err);

--- a/wrappers/couch_rocksdb.cc
+++ b/wrappers/couch_rocksdb.cc
@@ -187,15 +187,14 @@ couchstore_error_t couchstore_save_documents(Db *db, Doc* const docs[], DocInfo 
 {
     unsigned i;
     uint16_t metalen;
-    uint8_t metabuf[METABUF_MAXLEN];
     uint8_t *buf;
     rocksdb::Status status;
     rocksdb::WriteBatch wb;
 
+    buf = (uint8_t*)malloc(sizeof(metalen) + METABUF_MAXLEN + DATABUF_MAXLEN);
+
     for (i=0;i<numdocs;++i){
-        metalen = _docinfo_to_buf(infos[i], metabuf);
-        buf = (uint8_t*)malloc(sizeof(metalen) + metalen + docs[i]->data.size);
-        memcpy(buf + sizeof(metalen), metabuf, metalen);
+        metalen = _docinfo_to_buf(infos[i], buf + sizeof(metalen));
         memcpy(buf, &metalen, sizeof(metalen));
         memcpy(buf + sizeof(metalen) + metalen, docs[i]->data.buf, docs[i]->data.size);
 
@@ -204,8 +203,8 @@ couchstore_error_t couchstore_save_documents(Db *db, Doc* const docs[], DocInfo 
                               sizeof(metalen) + metalen + docs[i]->data.size));
 
         infos[i]->db_seq = 0;
-        free(buf);
     }
+    free(buf);
     status = db->db->Write(*db->write_options, &wb);
     if (!status.ok()) {
         printf("ERR %s\n", status.ToString().c_str());


### PR DESCRIPTION
buffer size is set to ~META_MAXLEN+DATA_MAXLEN.
DATA_MAXLEN is set as the upper bound for uniform
distribution and is set to median + 5*(standard deviation)
for normal distribution