### PR TITLE
Check if user provided paths are empty

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,17 @@ include_directories(BEFORE ${CMAKE_SOURCE_DIR}/utils)
 include_directories(BEFORE ${CMAKE_SOURCE_DIR}/bench)
 include_directories(BEFORE ${CMAKE_SOURCE_DIR}/include)
 include_directories(BEFORE ${CMAKE_SOURCE_DIR}/wrappers)
-include_directories(BEFORE ${CMAKE_INCLUDE_PATH})
+
+if (NOT "${CMAKE_INCLUDE_PATH}" STREQUAL "")
+    include_directories(BEFORE ${CMAKE_INCLUDE_PATH})
+endif()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GNU_SOURCE -D__DEBUG")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -L${CMAKE_LIBRARY_PATH} -std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+
+if (NOT "${CMAKE_LIBRARY_PATH}" STREQUAL "")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -L${CMAKE_LIBRARY_PATH}")
+endif()
 
 if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)


### PR DESCRIPTION
If user does not provide `CMAKE_LIBRARY_PATH`, flag `-std=c++11` will be hidden by preceding `-L` which causes compile error on old gcc.